### PR TITLE
Fix crash on "init_cam_poses"

### DIFF
--- a/include/basalt/calibration/calibration_helper.h
+++ b/include/basalt/calibration/calibration_helper.h
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <basalt/calibration/calibration.hpp>
 
 #include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_map.h>
 
 namespace basalt {
 
@@ -72,8 +73,7 @@ using CalibCornerMap = tbb::concurrent_unordered_map<TimeCamId, CalibCornerData,
                                                      std::hash<TimeCamId>>;
 
 using CalibInitPoseMap =
-    tbb::concurrent_unordered_map<TimeCamId, CalibInitPoseData,
-                                  std::hash<TimeCamId>>;
+    tbb::concurrent_map<TimeCamId, CalibInitPoseData>;
 
 class CalibHelper {
  public:


### PR DESCRIPTION
And @oseiskar

I first tried fixing the issue by changing various build options, but the only thing worked, as @Bercon noticed, was switching to Debug build. Apparently the issue wasn't the differing `-DEIGEN_INITIALIZE_MATRICES_BY_NAN` directive, but the `-O` optimization flag level. But that fix makes the calibrator optimization unbearably slow, so I tried to fix the crashing code instead.

The code in question is some TBB parallel loop using TBB containers. Changing type of the container whose `emplace()` crashed fixed the issue. I was able to do the camera calibration after this fix.

I suspect the code worked earlier when I and others had an older version of TBB.