### PR TITLE
Fixed a crash when trying to use invalid ransac result

### DIFF
--- a/src/calibration/calibraiton_helper.cpp
+++ b/src/calibration/calibraiton_helper.cpp
@@ -92,7 +92,8 @@ bool estimateTransformation(
   ransac.threshold_ = 1.0 - cos(atan(sqrt(2.0) * 1 / cam_calib.getParam()[0]));
   ransac.max_iterations_ = 50;
 
-  ransac.computeModel();
+  bool result = ransac.computeModel();
+  if (!result) return false;
 
   T_target_camera =
       Sophus::SE3d(ransac.model_coefficients_.topLeftCorner<3, 3>(),


### PR DESCRIPTION
And @oseiskar with this fix I managed to use the aprilgrid calibration. However I think we should record a better session where the entirety of the lens gets visited by the grid. Since the whole grid doesn't need to be in frame, it'd probably be best to keep 25% of the grid off screen and "move" the grid around 360 around the lens to ensure proper coverage.