### PR TITLE
Add max_intrinsics limiter to camera calib UI

### DIFF
--- a/include/basalt/calibration/cam_calib.h
+++ b/include/basalt/calibration/cam_calib.h
@@ -156,6 +156,9 @@ class CamCalib {
 
   pangolin::Var<bool> opt_intr;
   pangolin::Var<bool> opt_extrinsic_trans;
+  // maximum number of instrinsic parameters to optimize (including fx,fy,ppx,ppy)
+  // 0 means unlimited
+  pangolin::Var<int> max_intrinsics;
 
   pangolin::Var<bool> opt_until_convg;
   pangolin::Var<double> stop_thresh;

--- a/include/basalt/optimization/linearize.h
+++ b/include/basalt/optimization/linearize.h
@@ -116,6 +116,7 @@ struct LinearizeBase {
 
     bool opt_intrinsics;
     bool opt_extrinsic_trans;
+    int max_intrinsics = 0;
 
     // Cam-IMU options
     bool opt_cam_time_offset;

--- a/include/basalt/optimization/poses_optimize.h
+++ b/include/basalt/optimization/poses_optimize.h
@@ -112,13 +112,14 @@ class PosesOptimization {
 
   // Returns true when converged
   bool optimize(bool opt_intrinsics, bool opt_extrinsic_trans, double huber_thresh, double stop_thresh,
-                double &error, int &num_points, double &reprojection_error) {
+                int max_intrinsics, double &error, int &num_points, double &reprojection_error) {
     error = 0;
     num_points = 0;
 
     ccd.opt_intrinsics = opt_intrinsics;
     ccd.opt_extrinsic_trans = opt_extrinsic_trans;
     ccd.huber_thresh = huber_thresh;
+    ccd.max_intrinsics = max_intrinsics;
 
     LinearizePosesOpt<double, SparseHashAccumulator<double>> lopt(
         problem_size, timestam_to_pose, ccd);


### PR DESCRIPTION
Usage:
 1. Click all buttons up to and including init_cam_intr
 2. Optionally, click all the way to init_cam_extr
 3. Adjust max_intrinsics (NOTE: includes fx,fy,ppx,ppy in count)
 4. Click on init_cam_intr again
 5. Continue where you left of after 1 (and 2)

Limitation: if the intrinsic count is limited, will initialize everything except fx,fy,ppx,ppy to zero.